### PR TITLE
Docusaurus edit button should lead to edit view?

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -74,8 +74,7 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
-          // Please change this to your repo.
-          editUrl: "https://github.com/Hashnode/support/blob/main/",
+          editUrl: "https://github.com/Hashnode/support/edit/main/",
         },
 
         theme: {


### PR DESCRIPTION
Hi,

Just a tiny suggestion, you could link to the md doc in edit mode instead of view mode.
That's what most docusaurus sites do

Thanks for choosing docusaurus ;)