### PR TITLE
Add Hashnode Blog on Google Search Console

### DIFF
--- a/docs/google-search-console.md
+++ b/docs/google-search-console.md
@@ -1,0 +1,90 @@
+---
+id: google-search-console
+title: Add Hashnode Blog on Google Search Console
+---
+
+If you have just created a blog with Hashnode, here are some important tips for you. These tips are applicable for everyone, irrespective of which URL you chose for your Hashnode Blog, custom domain or hashnode.dev subdomain.
+
+## Tell Google about your new blogging destination
+
+Before you think about ranking on a certain keyword and getting link backs from high traffic fetching websites, you need to inform Google that your domain exists.
+
+One of the simplest and easiest ways to inform Google about your blog is by submitting your website on Google's Search Console. If you are a frequent blogger, chances are you are aware of how it works.
+
+Here are the steps to submit your blog to Google's Search Console:
+
+1.  Log in with your Google account on [Google's Search Console](https://search.google.com/search-console/about).
+
+2.  Click on "Add Property"
+
+![Google Search Console Screenshot](https://cdn.hashnode.com/res/hashnode/image/upload/v1597960215295/o4dwVl5JW.png?auto=compress)
+
+3.  Enter the name of the domain under the "URL prefix" property type section and click on "Continue."
+    
+![Verify the Domain on Google Search Console](https://cdn.hashnode.com/res/hashnode/image/upload/v1597960261890/Jk-cmVc_M.png?auto=compress)
+
+4.  Expand the "HTML tag" tab.
+    
+![Verify the domain through HTML tag](https://cdn.hashnode.com/res/hashnode/image/upload/v1597960299064/SomRhoGsb.png?auto=compress)
+
+5.  Copy the HTML tag.
+
+![HTML meta tag from Google Search Console](https://cdn.hashnode.com/res/hashnode/image/upload/v1597960330674/ZQdhu4F2K.png?auto=compress)
+
+6.  Go to your Blog's dashboard.
+
+![Townhall by Hashnode Screenshot](https://cdn.hashnode.com/res/hashnode/image/upload/v1615357422616/_tli8gbNz.png?auto=compress)
+
+7.  Navigate to the "Integration" tab and paste the HTML Tag inside the "Meta tags" field. Click on the "Update" button. This will clear the cache of your blog's homepage and insert the HTML tag provided by Google inside the `<head>` tag of your blog.
+
+![Hashnode's Blog Dashboard](https://cdn.hashnode.com/res/hashnode/image/upload/v1615357496477/H6BxAc1Ba.png?auto=compress)
+
+8.  Go back to Google Search Console and click on the "Verify" button. If you have followed the above steps correctly, Google should be able to find the meta tag and verify the domain.
+
+![Google Search Console's Verification Successful Screen](https://cdn.hashnode.com/res/hashnode/image/upload/v1597960410631/S6rj7rggD_.png?auto=compress)
+
+9.  Now comes the part where we tell Google about the links present on your blog. Go to the Sitemap section present on the sidebar on Google Search Console.
+
+![Sitemap on Google Search Console](https://cdn.hashnode.com/res/hashnode/image/upload/v1597960433879/7d4WUvi1p.png?auto=compress)
+
+10. Every blog on Hashnode has a sitemap, and it's available at `/sitemap.xml`. For example [townhall.hashnode.com/sitemap.xml](https://townhall.hashnode.com/sitemap.xml). On the Google Search Console, enter `sitemap.xml` in the input field. *Don't prepend the slash `/`. Google has already added that for you.*
+
+![Sitemap on Google Search Console](https://cdn.hashnode.com/res/hashnode/image/upload/v1597960460447/Fh_5AgxFT.png?auto=compress)
+
+11. On successful submission, you should see the following screen.
+
+![Sitemap submission successful](https://cdn.hashnode.com/res/hashnode/image/upload/v1597960489075/XLQ--3Qaf.png?auto=compress)That's it! Google is now aware of your blog. It'll crawl your sitemap periodically and index your blog posts, even the future ones automatically.
+
+## Enable AMP on your Hashnode blog
+
+There's no denying that Google prefers AMP pages than normal web pages on mobile searches. Hence, you can improve your Hashnode Blog's ranking on mobile searches by enabling AMP on your blog. Follow these steps:
+
+1.  Go to your Blog's dashboard
+
+![Townhall by Hashnode Screenshot](https://cdn.hashnode.com/res/hashnode/image/upload/v1615357422616/_tli8gbNz.png?auto=compress)
+
+2.  Navigate to the "SEO" tab
+
+![SEO Tab](https://cdn.hashnode.com/res/hashnode/image/upload/v1615357465328/qqcoG0SVu.png?auto=compress)
+
+3.  Scroll down and check the option "Enable AMP."
+
+![Enable AMP on Hashnode](https://cdn.hashnode.com/res/hashnode/image/upload/v1597960590203/sz4_sraRp.png?auto=compress)
+
+Google will take up to a day to validate AMP pages on your blog and replace your normal links with AMP pages for mobile searches automatically. Here's a snapshot of how my blog result looks like on Google search.
+
+![AMP search result on Google](https://cdn.hashnode.com/res/hashnode/image/upload/v1597960615121/mOoOMhxs1.png?auto=compress)
+
+## Link trail from your social media accounts
+
+Linking your blog from your social media accounts is another great way to tell Google about your blog.
+
+On Twitter, you can add a link in your bio and also inside the "Website" field. Refer to the screenshot below.
+
+![Catalin Pit's Profile on Twitter](https://cdn.hashnode.com/res/hashnode/image/upload/v1597960637455/6Xz-3IX_Q.png?auto=compress)
+
+On Linkedin, you can add your blog to the featured section:
+
+![LinkedIn](https://cdn.hashnode.com/res/hashnode/image/upload/v1597960658284/qhHSPl7nY.png?auto=compress)
+
+Similarly, you can link your blog from the bio section of Instagram and Facebook pages as well.

--- a/sidebars.js
+++ b/sidebars.js
@@ -3,7 +3,7 @@ module.exports = {
     "Getting Started": ['using-hashnode', 'hashnode-glossary', 'create-personal-blog', 'create-team-blog', 'contact-support','change-log','bug-reports-and-feature-request'],
     "Mapping to Custom Domain": ['mapping-domain','mapping-cloudflare', 'mapping-godaddy', 'mapping-namecheap', 'mapping-domain-faqs'],
     "Writing and Editing" :['write-an-article', 'tags', 'markdown-guidelines', 'embeds', 'edit-url-type', 'edit-slug', 'edit-article', 'edit-drafts', 'cover-photo'], 
-    "Settings & Customization":['account-settings', 'analytics', 'export-articles','general-settings', 'github-backup', 'import-articles','integrations', 'newsletter', 'seo', 'static-pages',  'teams-blog-settings', 'widgets' ],
+    "Settings & Customization":['account-settings', 'analytics', 'export-articles','general-settings', 'github-backup', 'import-articles','integrations', 'newsletter', 'seo', 'google-search-console', 'static-pages',  'teams-blog-settings', 'widgets' ],
     "Safety & Policies": ['community-code-of-conduct', 'report-copyright-infringement', 'report-posts-and-users'], 
     "FAQs" : ['faqs'],
   },


### PR DESCRIPTION
Added content explaining how to add Hashnode blogs to Google's Search Console. 