### PR TITLE
Fixed CodeSandbox typo

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -51,7 +51,7 @@ Hashnode supports the following embeds:
 - Instagram Posts.
 - Giphy GIFs.
 - Runkit.
-- CodeSanbox.
+- CodeSandbox.
 
 ## How can I add a table in a blog post?
 


### PR DESCRIPTION
There was a typo in the `faqs.md` file.

I corrected it!