### PR TITLE
fix a couple markdown examples

### DIFF
--- a/docs/markdown-guidelines.md
+++ b/docs/markdown-guidelines.md
@@ -68,12 +68,14 @@ This is a standard sentence with `console.log("yeah!")` in it.
 
 Wrap the code blocks with triple Grave accent keys. **```** for showing big blocks of code in your content. For example:
 
+~~~
 ```
 if (isServer && user) {
-    store.userStore.currentUser = user;
+  store.userStore.currentUser = user;
 }
 ```
-
+~~~
+    
 The above will look like:
 
 ```
@@ -84,7 +86,22 @@ if (isServer && user) {
 
 Hashnode supports generic code highlighting. This will be applied to the code blocks after you publish the content.
 
-You can select which highlighting to use manually by appending the code language after the beginning Triple Grave accent keys like so **```javascript**.
+You can select which highlighting to use manually by appending the code language after the beginning Triple Grave accent keys like so **```javascript**. For example:
+
+~~~
+```javascript
+function hello() {
+  console.log("Hello Hashnode!")
+}
+```
+~~~
+
+The above will look similar to:
+```javascript
+function hello() {
+  console.log("Hello Hashnode!")
+}
+```
 
 ## Text Formatting
 
@@ -98,8 +115,13 @@ The bold and italics markdown syntax works inside almost any block-level element
 
 Use the greater than sign to format a text as a quote. For example:
 
+```
 > Where there is a will, there is a way!
-Where there is a will, there is a way!
+```
+
+The above will look like:
+
+> Where there is a will, there is a way!
 
 ## Links
 


### PR DESCRIPTION
When creating my Hashnode blog I was exploring the Hashnode support docs and came across the Markdown Guidelines page. Going through it I noticed a couple issues in some of the example markdown and figured I would create a PR to fix them. 

Here are my proposed changes:
## Block Code Section
**Problem**: When showing an example of using the **```** triple Grave accent keys to create a code block in markdown it is rendered as a code block instead of showing the triple Grave accent key.

Image to show the problem:
![image](https://user-images.githubusercontent.com/20310709/154808287-ff5ecb6f-08a4-485f-9d0f-3124d937d97c.png)

**Proposed Solution**: I wrapped the code block markdown format in another method of creating a code block to escape the **```** triple Grave accent keys.  

Image to show proposed solution:
![image](https://user-images.githubusercontent.com/20310709/154808361-2b103fc3-7023-43b1-bf40-e12e21978c7a.png)

**Problem**: There is no example to show how the markdown syntax highlighting works, only a brief description of how to do it.

**Proposed Solution**: Add a quick example of using markdown for syntax highlighting.

Image to show proposed solution:
![image](https://user-images.githubusercontent.com/20310709/154808482-3a3840eb-2246-4574-9ea9-c3b408598b1a.png)

## Quotes Section
**Problem**: When showing an example of how to write a quote in markdown, it renders it as a quote instead of showing the markdown implementation.

Image to show the problem:
![image](https://user-images.githubusercontent.com/20310709/154808556-e1a0a58d-f615-419c-843e-bb7dea97cdb0.png)

**Proposed Solution**: Create a code block to show an example of how to write it in markdown

Image to show the proposed solution:
![image](https://user-images.githubusercontent.com/20310709/154809701-8886549b-187b-4768-9c89-83dd0c92d25f.png)

Sorry for how lengthy this is. Let me know if there is anything else that needs to be done. Thanks!