### PR TITLE
ISSUE #73

### DIFF
--- a/docs/mapping-namecheap.md
+++ b/docs/mapping-namecheap.md
@@ -5,7 +5,7 @@ title: Mapping Domain from Namecheap
 
 This section covers how to map a domain hosted or purchased on Namecheap to Hashnode.
 
-1. Create an account on [NameCheap](http://namecheap.com/). 
+1. Create an account on [NameCheap](http://namecheap.com/).
 
 ![Namecheap Homepage](https://cdn.hashnode.com/res/hashnode/image/upload/v1611181169490/zqRV_MW0X.png?auto=compress)
 
@@ -21,9 +21,17 @@ This section covers how to map a domain hosted or purchased on Namecheap to Hash
 
 5. Navigate to the **Advanced DNS** tab.
 
-6. Click on the **Add New Record** button in the **Host Records** section. 
+6. Click on the **Add New Record** button in the **Host Records** section.
 
 7. Select **CNAME Record** from the drop-down menu. Enter `@` under host, `hashnode.network` under target, and a **TTL** of 30 minutes.
 
+8. Next, select **A Record** from the drop-down menu. Enter @ under the host, 76.76.21.21 under the value, and **TTL** of 30 minutes.
+
+9. Check for the section titled **NAMESERVERS**, click the drop-down menu and select **Custom DNS**. Two input fields will be revealed,and add the texts below in the input fields.
+
+```
+ns1.vercel-dns.com
+ns2.vercel-dns.com
+```
 
 > Domain propagation (the process whereby nameservers update across the internet to reflect a change in a domain's DNS record) takes 0 - 48 hours to start working in all locations across the internet. Once your domain propagates, we will automatically provision an SSL certificate for you when you visit your blog for the first time.


### PR DESCRIPTION
This pull request addresses issue #73 , where some readers are experiencing an issue in Nigeria where network providers are blocked from accessing developer-focused websites on Hashnode.

**Changes Made**:
Update the documentation `mapping-namecheap.md` which was the easiest to test with a real-life example.

**Solution**:
Point the blog to a custom root domain and not as sub-domain. If your domain name registrar isn't Vercel, follow through with the domain mapping documentation and change the NAMESERVERS from the default to `ns1.vercel-dns.com` and `ns2.vercel-dns.com`